### PR TITLE
Add JWT Authorization to Swagger UI and Protected Endpoints

### DIFF
--- a/PlatformFlower/Program.cs
+++ b/PlatformFlower/Program.cs
@@ -18,7 +18,41 @@ namespace PlatformFlower
             builder.Services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
-            builder.Services.AddSwaggerGen();
+            builder.Services.AddSwaggerGen(options =>
+            {
+                options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+                {
+                    Title = "PlatformFlower API",
+                    Version = "v1",
+                    Description = "API for PlatformFlower application with JWT Authentication"
+                });
+
+                // Add JWT Authentication to Swagger
+                options.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+                {
+                    Name = "Authorization",
+                    Type = Microsoft.OpenApi.Models.SecuritySchemeType.Http,
+                    Scheme = "Bearer",
+                    BearerFormat = "JWT",
+                    In = Microsoft.OpenApi.Models.ParameterLocation.Header,
+                    Description = "Enter 'Bearer' [space] and then your valid token in the text input below.\r\n\r\nExample: \"Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\""
+                });
+
+                options.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
+                {
+                    {
+                        new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+                        {
+                            Reference = new Microsoft.OpenApi.Models.OpenApiReference
+                            {
+                                Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
+                                Id = "Bearer"
+                            }
+                        },
+                        new string[] {}
+                    }
+                });
+            });
             // Connect to the database using Entity Framework Core
             builder.Services.AddDbContext<FlowershopContext>(options =>
             {


### PR DESCRIPTION
- Configure Swagger with JWT Bearer authentication support
- Add Authorization header input field in Swagger UI
- Add [Authorize] attribute to protected endpoints
- Add new GET /api/auth/profile endpoint (protected)
- Users can now test JWT authentication directly in Swagger
- Improve API documentation with security requirements