### PR TITLE
feat: upgrade password security from SHA256 to bcrypt

### DIFF
--- a/PlatformFlower/PlatformFlower.csproj
+++ b/PlatformFlower/PlatformFlower.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">


### PR DESCRIPTION
- Add BCrypt.Net-Next package for secure password hashing
- Replace SHA256 with bcrypt (work factor 12) for new passwords
- Add backward compatibility for existing SHA256 passwords
- Implement automatic password upgrade on successful login
- Add VerifyPassword method with fallback to legacy verification
- Improve security against brute force and rainbow table attacks