### PR TITLE
feat: add security protection for user profile updates

### DIFF
--- a/PlatformFlower/Controllers/UserController.cs
+++ b/PlatformFlower/Controllers/UserController.cs
@@ -33,8 +33,10 @@ namespace PlatformFlower.Controllers
 
         /// <summary>
         /// Update current user's information including avatar upload
+        /// SECURITY NOTE: This endpoint only allows updating UserInfo fields.
+        /// User.Type (role) cannot be changed via this endpoint - admin-only functionality.
         /// </summary>
-        /// <param name="updateDto">Update data</param>
+        /// <param name="updateDto">Update data (UserInfo fields only)</param>
         /// <returns>Updated user information</returns>
         [HttpPut("profile")]
         public async Task<ActionResult<ApiResponse<UserResponseDto>>> UpdateProfile([FromForm] UpdateUserInfoDto updateDto)


### PR DESCRIPTION
SECURITY ENHANCEMENT:
- Prevent users from modifying their own role/type via profile update API
- Add ValidateProfileUpdateSecurity() method with reflection-based validation
- Block attempts to modify restricted properties: Type, Role, Status, UserId, Password
- Throw SecurityException for privilege escalation attempts
- Add comprehensive security logging and documentation
- Maintain separation between UserInfo updates and User role management
- Ensure only admin endpoints can modify user roles/types

TECHNICAL DETAILS:
- Runtime validation of DTO properties to prevent injection attacks
- Clear documentation about security restrictions in API endpoints
- Backward compatible - existing profile update functionality unchanged
- Enhanced error handling for security violations