### PR TITLE
refactor: Remove redundant type and quantity fields from Seller entity

### DIFF
--- a/Database.txt
+++ b/Database.txt
@@ -29,14 +29,12 @@ CREATE TABLE Seller (
     seller_id INT IDENTITY(1,1) PRIMARY KEY,
     user_id INT NOT NULL,
     shop_name NVARCHAR(255) NOT NULL,
-    address_seller NVARCHAR(255) NOT NULL,  -- Đảm bảo thuộc tính này tồn tại
-    type NVARCHAR(20) DEFAULT 'seller',
+    address_seller NVARCHAR(255) NOT NULL,
     created_at DATETIME DEFAULT GETDATE(),
     updated_at DATETIME DEFAULT GETDATE(),
     total_product INT DEFAULT 0,
     role NVARCHAR(20) NOT NULL CHECK (role IN ('individual', 'enterprise')),
     introduction TEXT,
-    quantity INT DEFAULT 0,
     FOREIGN KEY (user_id) REFERENCES Users(user_id)
 );
 

--- a/PlatformFlower/Entities/Seller.cs
+++ b/PlatformFlower/Entities/Seller.cs
@@ -13,8 +13,6 @@ public partial class Seller
 
     public string AddressSeller { get; set; } = null!;
 
-    public string? Type { get; set; }
-
     public DateTime? CreatedAt { get; set; }
 
     public DateTime? UpdatedAt { get; set; }
@@ -24,8 +22,6 @@ public partial class Seller
     public string Role { get; set; } = null!;
 
     public string? Introduction { get; set; }
-
-    public int? Quantity { get; set; }
 
     public virtual ICollection<FlowerInfo> FlowerInfos { get; set; } = new List<FlowerInfo>();
 

--- a/PlatformFlower/FlowershopContext.cs
+++ b/PlatformFlower/FlowershopContext.cs
@@ -288,9 +288,6 @@ public partial class FlowershopContext : DbContext
             entity.Property(e => e.Introduction)
                 .HasColumnType("text")
                 .HasColumnName("introduction");
-            entity.Property(e => e.Quantity)
-                .HasDefaultValue(0)
-                .HasColumnName("quantity");
             entity.Property(e => e.Role)
                 .HasMaxLength(20)
                 .HasColumnName("role");
@@ -300,10 +297,6 @@ public partial class FlowershopContext : DbContext
             entity.Property(e => e.TotalProduct)
                 .HasDefaultValue(0)
                 .HasColumnName("total_product");
-            entity.Property(e => e.Type)
-                .HasMaxLength(20)
-                .HasDefaultValue("seller")
-                .HasColumnName("type");
             entity.Property(e => e.UpdatedAt)
                 .HasDefaultValueSql("(getdate())")
                 .HasColumnType("datetime")

--- a/PlatformFlower/Scripts/CreateFlowershopDatabase.sql
+++ b/PlatformFlower/Scripts/CreateFlowershopDatabase.sql
@@ -31,14 +31,12 @@ CREATE TABLE Seller (
     seller_id INT IDENTITY(1,1) PRIMARY KEY,
     user_id INT NOT NULL,
     shop_name NVARCHAR(255) NOT NULL,
-    address_seller NVARCHAR(255) NOT NULL,  -- Đảm bảo thuộc tính này tồn tại
-    type NVARCHAR(20) DEFAULT 'seller',
+    address_seller NVARCHAR(255) NOT NULL,
     created_at DATETIME DEFAULT GETDATE(),
     updated_at DATETIME DEFAULT GETDATE(),
     total_product INT DEFAULT 0,
     role NVARCHAR(20) NOT NULL CHECK (role IN ('individual', 'enterprise')),
     introduction TEXT,
-    quantity INT DEFAULT 0,
     FOREIGN KEY (user_id) REFERENCES Users(user_id)
 );
 


### PR DESCRIPTION
- Remove 'type' field from Seller entity (redundant with User.Type)
- Remove 'quantity' field from Seller entity (not needed for seller info)
- Update database schema and migration scripts
- Simplify Seller entity to focus on seller-specific information only

This change follows SOLID principles by removing redundant data and maintaining single source of truth for user types in User entity.