### PR TITLE
feat: Combine seller registration and update into single upsert API

### DIFF
--- a/PlatformFlower/Models/DTOs/UpdateSellerDto.cs
+++ b/PlatformFlower/Models/DTOs/UpdateSellerDto.cs
@@ -2,7 +2,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace PlatformFlower.Models.DTOs
 {
-    public class RegisterSellerDto
+    public class UpdateSellerDto
     {
         [Required(ErrorMessage = "Shop name is required")]
         [StringLength(255, MinimumLength = 2, ErrorMessage = "Shop name must be between 2 and 255 characters")]

--- a/PlatformFlower/Services/Seller/ISellerService.cs
+++ b/PlatformFlower/Services/Seller/ISellerService.cs
@@ -4,7 +4,7 @@ namespace PlatformFlower.Services.Seller
 {
     public interface ISellerService
     {
-        Task<SellerResponseDto> RegisterSellerAsync(int userId, RegisterSellerDto registerSellerDto);
+        Task<SellerResponseDto> UpsertSellerAsync(int userId, UpdateSellerDto sellerDto);
         Task<SellerResponseDto?> GetSellerByUserIdAsync(int userId);
         Task<SellerResponseDto?> GetSellerByIdAsync(int sellerId);
         Task<bool> IsUserSellerAsync(int userId);


### PR DESCRIPTION
- Replace separate register/update endpoints with unified PUT /api/seller/profile
- Implement UpsertSellerAsync method that handles both create and update logic
- Auto-detect if user is new seller (create) or existing seller (update)
- Update User.Type to 'seller' only when creating new seller
- Remove RegisterSellerDto, use UpdateSellerDto for both operations
- Simplify validation logic with unified ValidateShopNameAsync method
- Provide appropriate response messages based on operation type

Benefits:
- Single endpoint for both register and update operations
- Cleaner API design following DRY principle
- Better user experience - no need to distinguish between register/update
- Easier code maintenance with unified business logic