### PR TITLE
refactor: Reorganize seller services into Profile folder structure

### DIFF
--- a/PlatformFlower/Controllers/SellerController.cs
+++ b/PlatformFlower/Controllers/SellerController.cs
@@ -5,7 +5,7 @@ using PlatformFlower.Models.DTOs;
 using PlatformFlower.Services.Common.Logging;
 using PlatformFlower.Services.Common.Response;
 using PlatformFlower.Services.Common.Validation;
-using PlatformFlower.Services.Seller;
+using PlatformFlower.Services.Seller.Profile;
 
 namespace PlatformFlower.Controllers
 {
@@ -14,13 +14,13 @@ namespace PlatformFlower.Controllers
     [Authorize]
     public class SellerController : ControllerBase
     {
-        private readonly ISellerService _sellerService;
+        private readonly ISellerProfileService _sellerService;
         private readonly IResponseService _responseService;
         private readonly IValidationService _validationService;
         private readonly IAppLogger _logger;
 
         public SellerController(
-            ISellerService sellerService,
+            ISellerProfileService sellerService,
             IResponseService responseService,
             IValidationService validationService,
             IAppLogger logger)

--- a/PlatformFlower/Program.cs
+++ b/PlatformFlower/Program.cs
@@ -100,7 +100,7 @@ namespace PlatformFlower
             builder.Services.AddScoped<PlatformFlower.Services.Auth.IJwtService, PlatformFlower.Services.Auth.JwtService>();
 
             // Register Seller services
-            builder.Services.AddScoped<PlatformFlower.Services.Seller.ISellerService, PlatformFlower.Services.Seller.SellerServiceSimple>();
+            builder.Services.AddScoped<PlatformFlower.Services.Seller.Profile.ISellerProfileService, PlatformFlower.Services.Seller.Profile.SellerProfileService>();
 
             // Register Email services
             builder.Services.AddSingleton<PlatformFlower.Services.Email.IEmailConfiguration, PlatformFlower.Services.Email.EmailConfiguration>();

--- a/PlatformFlower/Services/Seller/Profile/ISellerProfileService.cs
+++ b/PlatformFlower/Services/Seller/Profile/ISellerProfileService.cs
@@ -1,8 +1,8 @@
 using PlatformFlower.Models.DTOs;
 
-namespace PlatformFlower.Services.Seller
+namespace PlatformFlower.Services.Seller.Profile
 {
-    public interface ISellerService
+    public interface ISellerProfileService
     {
         Task<SellerResponseDto> UpsertSellerAsync(int userId, UpdateSellerDto sellerDto);
         Task<SellerResponseDto?> GetSellerByUserIdAsync(int userId);

--- a/PlatformFlower/Services/Seller/Profile/SellerProfileService.cs
+++ b/PlatformFlower/Services/Seller/Profile/SellerProfileService.cs
@@ -3,15 +3,15 @@ using PlatformFlower.Models.DTOs;
 using PlatformFlower.Services.Common.Logging;
 using PlatformFlower.Services.User.Profile;
 
-namespace PlatformFlower.Services.Seller
+namespace PlatformFlower.Services.Seller.Profile
 {
-    public class SellerServiceSimple : ISellerService
+    public class SellerProfileService : ISellerProfileService
     {
         private readonly FlowershopContext _context;
         private readonly IProfileService _profileService;
         private readonly IAppLogger _logger;
 
-        public SellerServiceSimple(
+        public SellerProfileService(
             FlowershopContext context,
             IProfileService profileService,
             IAppLogger logger)


### PR DESCRIPTION
- Move ISellerService → Services/Seller/Profile/ISellerProfileService
- Move SellerServiceSimple → Services/Seller/Profile/SellerProfileService
- Update namespace from Services.Seller to Services.Seller.Profile
- Update service registration in Program.cs and SellerController
- Rename class SellerServiceSimple → SellerProfileService for clarity

Benefits:
- Clear separation of seller profile management functionality
- Consistent with User/Profile structure pattern
- Better organization for future seller features (Products, Orders)
- More descriptive service names that indicate specific purpose