### PR TITLE
feat: Add status, created_at, updated_at fields to Category

### DIFF
--- a/Database.txt
+++ b/Database.txt
@@ -59,7 +59,11 @@ GO
 -- Bảng Category cho các loại hoa
 CREATE TABLE Category (
     category_id INT IDENTITY(1,1) PRIMARY KEY,
-    category_name NVARCHAR(255) NOT NULL
+    category_name NVARCHAR(255) NOT NULL,
+    status NVARCHAR(20) DEFAULT 'active',
+    created_at DATETIME DEFAULT GETDATE(),
+    updated_at DATETIME DEFAULT GETDATE(),
+    CONSTRAINT chk_category_status CHECK (status IN ('active', 'inactive'))
 );
 GO
 

--- a/PlatformFlower/Entities/Category.cs
+++ b/PlatformFlower/Entities/Category.cs
@@ -9,5 +9,11 @@ public partial class Category
 
     public string CategoryName { get; set; } = null!;
 
+    public string? Status { get; set; }
+
+    public DateTime? CreatedAt { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
+
     public virtual ICollection<FlowerInfo> FlowerInfos { get; set; } = new List<FlowerInfo>();
 }

--- a/PlatformFlower/FlowershopContext.cs
+++ b/PlatformFlower/FlowershopContext.cs
@@ -92,6 +92,18 @@ public partial class FlowershopContext : DbContext
             entity.Property(e => e.CategoryName)
                 .HasMaxLength(255)
                 .HasColumnName("category_name");
+            entity.Property(e => e.Status)
+                .HasMaxLength(20)
+                .HasDefaultValue("active")
+                .HasColumnName("status");
+            entity.Property(e => e.CreatedAt)
+                .HasDefaultValueSql("(getdate())")
+                .HasColumnType("datetime")
+                .HasColumnName("created_at");
+            entity.Property(e => e.UpdatedAt)
+                .HasDefaultValueSql("(getdate())")
+                .HasColumnType("datetime")
+                .HasColumnName("updated_at");
         });
 
         modelBuilder.Entity<FlowerInfo>(entity =>

--- a/PlatformFlower/Scripts/CreateFlowershopDatabase.sql
+++ b/PlatformFlower/Scripts/CreateFlowershopDatabase.sql
@@ -61,7 +61,11 @@ GO
 -- Bảng Category cho các loại hoa
 CREATE TABLE Category (
     category_id INT IDENTITY(1,1) PRIMARY KEY,
-    category_name NVARCHAR(255) NOT NULL
+    category_name NVARCHAR(255) NOT NULL,
+    status NVARCHAR(20) DEFAULT 'active',
+    created_at DATETIME DEFAULT GETDATE(),
+    updated_at DATETIME DEFAULT GETDATE(),
+    CONSTRAINT chk_category_status CHECK (status IN ('active', 'inactive'))
 );
 GO
 


### PR DESCRIPTION
- Update Category entity with new fields: Status, CreatedAt, UpdatedAt
- Update DbContext configuration for Category table mapping
- Update database scripts to include new columns with constraints
- Add status constraint to allow only 'active' and 'inactive' values
- Set default values: status='active', timestamps=GETDATE()

Database changes:
- Category table now supports audit trail and soft delete
- Consistent with other entities (Users, Seller, Report)
- Better admin management capabilities