### PR TITLE
feat: Add Admin Category Management API with Universal CRUD endpoint

### DIFF
--- a/PlatformFlower/Controllers/Admin/AdminCategoryController.cs
+++ b/PlatformFlower/Controllers/Admin/AdminCategoryController.cs
@@ -1,0 +1,174 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using PlatformFlower.Models.DTOs;
+using PlatformFlower.Services.Admin.CategoryManagement;
+
+namespace PlatformFlower.Controllers.Admin
+{
+    [ApiController]
+    [Route("api/admin/categories")]
+    [Authorize(Roles = "admin")]
+    public class AdminCategoryController : ControllerBase
+    {
+        private readonly ICategoryManagementService _categoryManagementService;
+
+        public AdminCategoryController(ICategoryManagementService categoryManagementService)
+        {
+            _categoryManagementService = categoryManagementService;
+        }
+
+        /// <summary>
+        /// Universal Category Management API - Handles CREATE, UPDATE, DELETE in one endpoint
+        /// </summary>
+        /// <param name="request">Category management request</param>
+        /// <returns>Category response</returns>
+        /// <remarks>
+        /// Operations:
+        /// - CREATE: Set CategoryId = 0 or null, provide CategoryName
+        /// - UPDATE: Set CategoryId > 0, provide CategoryName and/or Status, IsDeleted = false
+        /// - DELETE: Set CategoryId > 0, IsDeleted = true
+        /// 
+        /// Examples:
+        /// 
+        /// CREATE:
+        /// {
+        ///   "categoryId": 0,
+        ///   "categoryName": "New Category",
+        ///   "status": "active",
+        ///   "isDeleted": false
+        /// }
+        ///
+        /// UPDATE:
+        /// {
+        ///   "categoryId": 5,
+        ///   "categoryName": "Updated Category Name",
+        ///   "status": "active",
+        ///   "isDeleted": false
+        /// }
+        ///
+        /// DELETE:
+        /// {
+        ///   "categoryId": 5,
+        ///   "isDeleted": true
+        /// }
+        /// </remarks>
+        [HttpPost("manage")]
+        public async Task<ActionResult<CategoryResponseDto>> ManageCategory([FromBody] CategoryManageRequestDto request)
+        {
+            try
+            {
+                var result = await _categoryManagementService.ManageCategoryAsync(request);
+                
+                // Determine operation type for response message
+                string operation = request.CategoryId == null || request.CategoryId == 0 ? "created" :
+                                 request.IsDeleted ? "deleted" : "updated";
+                
+                return Ok(new
+                {
+                    success = true,
+                    message = $"Category {operation} successfully",
+                    operation = operation,
+                    data = result
+                });
+            }
+            catch (ArgumentException ex)
+            {
+                return BadRequest(new
+                {
+                    success = false,
+                    message = ex.Message,
+                    error = "ValidationError"
+                });
+            }
+            catch (InvalidOperationException ex)
+            {
+                return BadRequest(new
+                {
+                    success = false,
+                    message = ex.Message,
+                    error = "OperationError"
+                });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new
+                {
+                    success = false,
+                    message = "An error occurred while processing the request",
+                    error = "InternalServerError",
+                    details = ex.Message
+                });
+            }
+        }
+
+        /// <summary>
+        /// Get all categories
+        /// </summary>
+        /// <returns>List of all categories</returns>
+        [HttpGet]
+        public async Task<ActionResult<List<CategoryResponseDto>>> GetAllCategories()
+        {
+            try
+            {
+                var result = await _categoryManagementService.GetAllCategoriesAsync();
+
+                return Ok(new
+                {
+                    success = true,
+                    message = "Categories retrieved successfully",
+                    data = result
+                });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new
+                {
+                    success = false,
+                    message = "An error occurred while retrieving categories",
+                    error = "InternalServerError",
+                    details = ex.Message
+                });
+            }
+        }
+
+        /// <summary>
+        /// Get category by ID
+        /// </summary>
+        /// <param name="id">Category ID</param>
+        /// <returns>Category details</returns>
+        [HttpGet("{id}")]
+        public async Task<ActionResult<CategoryResponseDto>> GetCategoryById(int id)
+        {
+            try
+            {
+                var result = await _categoryManagementService.GetCategoryByIdAsync(id);
+
+                if (result == null)
+                {
+                    return NotFound(new
+                    {
+                        success = false,
+                        message = $"Category with ID {id} not found"
+                    });
+                }
+
+                return Ok(new
+                {
+                    success = true,
+                    message = "Category retrieved successfully",
+                    data = result
+                });
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new
+                {
+                    success = false,
+                    message = "An error occurred while retrieving the category",
+                    error = "InternalServerError",
+                    details = ex.Message
+                });
+            }
+        }
+    }
+}

--- a/PlatformFlower/Models/DTOs/CategoryManagementDto.cs
+++ b/PlatformFlower/Models/DTOs/CategoryManagementDto.cs
@@ -1,0 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace PlatformFlower.Models.DTOs
+{
+    public class CategoryManageRequestDto
+    {
+        /// <summary>
+        /// Category ID - 0 or null for CREATE, > 0 for UPDATE/DELETE
+        /// </summary>
+        public int? CategoryId { get; set; }
+
+        /// <summary>
+        /// Category name - required for CREATE and UPDATE
+        /// </summary>
+        [StringLength(255, ErrorMessage = "Category name cannot exceed 255 characters")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Status - 'active' or 'inactive'
+        /// </summary>
+        [StringLength(20)]
+        public string? Status { get; set; }
+
+        /// <summary>
+        /// Set to true for DELETE operation (soft delete)
+        /// </summary>
+        public bool IsDeleted { get; set; } = false;
+    }
+
+    public class CategoryResponseDto
+    {
+        public int CategoryId { get; set; }
+        public string CategoryName { get; set; } = null!;
+        public string? Status { get; set; }
+        public DateTime? CreatedAt { get; set; }
+        public DateTime? UpdatedAt { get; set; }
+        public int FlowerCount { get; set; } // Number of flowers in this category
+    }
+
+
+}

--- a/PlatformFlower/Program.cs
+++ b/PlatformFlower/Program.cs
@@ -104,6 +104,7 @@ namespace PlatformFlower
 
             // Register Admin services
             builder.Services.AddScoped<PlatformFlower.Services.Admin.UserManagement.IUserManagementService, PlatformFlower.Services.Admin.UserManagement.UserManagementService>();
+            builder.Services.AddScoped<PlatformFlower.Services.Admin.CategoryManagement.ICategoryManagementService, PlatformFlower.Services.Admin.CategoryManagement.CategoryManagementService>();
 
             // Register Email services
             builder.Services.AddSingleton<PlatformFlower.Services.Email.IEmailConfiguration, PlatformFlower.Services.Email.EmailConfiguration>();

--- a/PlatformFlower/Services/Admin/CategoryManagement/CategoryManagementService.cs
+++ b/PlatformFlower/Services/Admin/CategoryManagement/CategoryManagementService.cs
@@ -1,0 +1,195 @@
+using Microsoft.EntityFrameworkCore;
+using PlatformFlower.Entities;
+using PlatformFlower.Models.DTOs;
+
+namespace PlatformFlower.Services.Admin.CategoryManagement
+{
+    public class CategoryManagementService : ICategoryManagementService
+    {
+        private readonly FlowershopContext _context;
+
+        public CategoryManagementService(FlowershopContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<CategoryResponseDto> ManageCategoryAsync(CategoryManageRequestDto request)
+        {
+            // Validate request
+            ValidateRequest(request);
+
+            // Determine operation type
+            if (request.CategoryId == null || request.CategoryId == 0)
+            {
+                // CREATE operation
+                return await CreateCategoryAsync(request);
+            }
+            else if (request.IsDeleted)
+            {
+                // DELETE operation (soft delete)
+                return await DeleteCategoryAsync(request.CategoryId.Value);
+            }
+            else
+            {
+                // UPDATE operation
+                return await UpdateCategoryAsync(request);
+            }
+        }
+
+        private async Task<CategoryResponseDto> CreateCategoryAsync(CategoryManageRequestDto request)
+        {
+            // Check if category name already exists
+            var existingCategory = await _context.Categories
+                .FirstOrDefaultAsync(c => c.CategoryName.ToLower() == request.CategoryName!.ToLower());
+
+            if (existingCategory != null)
+            {
+                throw new InvalidOperationException($"Category '{request.CategoryName}' already exists");
+            }
+
+            var category = new Category
+            {
+                CategoryName = request.CategoryName!,
+                Status = request.Status ?? "active",
+                CreatedAt = DateTime.Now,
+                UpdatedAt = DateTime.Now
+            };
+
+            _context.Categories.Add(category);
+            await _context.SaveChangesAsync();
+
+            return await MapToCategoryResponseDto(category);
+        }
+
+        private async Task<CategoryResponseDto> UpdateCategoryAsync(CategoryManageRequestDto request)
+        {
+            var category = await _context.Categories
+                .FirstOrDefaultAsync(c => c.CategoryId == request.CategoryId);
+
+            if (category == null)
+            {
+                throw new InvalidOperationException($"Category with ID {request.CategoryId} not found");
+            }
+
+            // Check if new name conflicts with existing category (excluding current one)
+            if (!string.IsNullOrEmpty(request.CategoryName))
+            {
+                var existingCategory = await _context.Categories
+                    .FirstOrDefaultAsync(c => c.CategoryName.ToLower() == request.CategoryName.ToLower() 
+                                            && c.CategoryId != request.CategoryId);
+
+                if (existingCategory != null)
+                {
+                    throw new InvalidOperationException($"Category '{request.CategoryName}' already exists");
+                }
+
+                category.CategoryName = request.CategoryName;
+            }
+
+            if (!string.IsNullOrEmpty(request.Status))
+            {
+                category.Status = request.Status;
+            }
+
+            category.UpdatedAt = DateTime.Now;
+
+            await _context.SaveChangesAsync();
+
+            return await MapToCategoryResponseDto(category);
+        }
+
+        private async Task<CategoryResponseDto> DeleteCategoryAsync(int categoryId)
+        {
+            var category = await _context.Categories
+                .FirstOrDefaultAsync(c => c.CategoryId == categoryId);
+
+            if (category == null)
+            {
+                throw new InvalidOperationException($"Category with ID {categoryId} not found");
+            }
+
+            // Check if category has flowers
+            var flowerCount = await _context.FlowerInfos
+                .CountAsync(f => f.CategoryId == categoryId);
+
+            if (flowerCount > 0)
+            {
+                throw new InvalidOperationException($"Cannot delete category. It contains {flowerCount} flower(s). Please move or delete flowers first.");
+            }
+
+            // Soft delete - set status to inactive
+            category.Status = "inactive";
+            category.UpdatedAt = DateTime.Now;
+
+            await _context.SaveChangesAsync();
+
+            return await MapToCategoryResponseDto(category);
+        }
+
+        public async Task<List<CategoryResponseDto>> GetAllCategoriesAsync()
+        {
+            var categories = await _context.Categories
+                .OrderBy(c => c.CategoryName)
+                .ToListAsync();
+
+            var categoryDtos = new List<CategoryResponseDto>();
+            foreach (var category in categories)
+            {
+                categoryDtos.Add(await MapToCategoryResponseDto(category));
+            }
+
+            return categoryDtos;
+        }
+
+        public async Task<CategoryResponseDto?> GetCategoryByIdAsync(int categoryId)
+        {
+            var category = await _context.Categories
+                .FirstOrDefaultAsync(c => c.CategoryId == categoryId);
+
+            return category == null ? null : await MapToCategoryResponseDto(category);
+        }
+
+        private async Task<CategoryResponseDto> MapToCategoryResponseDto(Category category)
+        {
+            var flowerCount = await _context.FlowerInfos
+                .CountAsync(f => f.CategoryId == category.CategoryId);
+
+            return new CategoryResponseDto
+            {
+                CategoryId = category.CategoryId,
+                CategoryName = category.CategoryName,
+                Status = category.Status,
+                CreatedAt = category.CreatedAt,
+                UpdatedAt = category.UpdatedAt,
+                FlowerCount = flowerCount
+            };
+        }
+
+        private static void ValidateRequest(CategoryManageRequestDto request)
+        {
+            // For CREATE operation
+            if (request.CategoryId == null || request.CategoryId == 0)
+            {
+                if (string.IsNullOrWhiteSpace(request.CategoryName))
+                {
+                    throw new ArgumentException("Category name is required for creating a new category");
+                }
+            }
+            // For UPDATE operation
+            else if (!request.IsDeleted)
+            {
+                if (string.IsNullOrWhiteSpace(request.CategoryName) && string.IsNullOrWhiteSpace(request.Status))
+                {
+                    throw new ArgumentException("At least category name or status must be provided for update");
+                }
+            }
+
+            // Validate status if provided
+            if (!string.IsNullOrEmpty(request.Status) && 
+                request.Status != "active" && request.Status != "inactive")
+            {
+                throw new ArgumentException("Status must be either 'active' or 'inactive'");
+            }
+        }
+    }
+}

--- a/PlatformFlower/Services/Admin/CategoryManagement/ICategoryManagementService.cs
+++ b/PlatformFlower/Services/Admin/CategoryManagement/ICategoryManagementService.cs
@@ -1,0 +1,27 @@
+using PlatformFlower.Models.DTOs;
+
+namespace PlatformFlower.Services.Admin.CategoryManagement
+{
+    public interface ICategoryManagementService
+    {
+        /// <summary>
+        /// Universal category management - handles CREATE, UPDATE, DELETE in one API
+        /// </summary>
+        /// <param name="request">Category management request</param>
+        /// <returns>Category response with operation result</returns>
+        Task<CategoryResponseDto> ManageCategoryAsync(CategoryManageRequestDto request);
+
+        /// <summary>
+        /// Get all categories
+        /// </summary>
+        /// <returns>List of all categories</returns>
+        Task<List<CategoryResponseDto>> GetAllCategoriesAsync();
+
+        /// <summary>
+        /// Get category by ID
+        /// </summary>
+        /// <param name="categoryId">Category ID</param>
+        /// <returns>Category details</returns>
+        Task<CategoryResponseDto?> GetCategoryByIdAsync(int categoryId);
+    }
+}

--- a/PlatformFlower/Services/User/Auth/AuthServiceSimple.cs
+++ b/PlatformFlower/Services/User/Auth/AuthServiceSimple.cs
@@ -267,6 +267,10 @@ namespace PlatformFlower.Services.User.Auth
             {
                 Subject = new ClaimsIdentity(new[]
                 {
+                    new Claim(ClaimTypes.NameIdentifier, user.UserId.ToString()),
+                    new Claim(ClaimTypes.Name, user.Username),
+                    new Claim(ClaimTypes.Email, user.Email),
+                    new Claim(ClaimTypes.Role, user.Type), // Sử dụng ClaimTypes.Role thay vì "type"
                     new Claim("user_id", user.UserId.ToString()),
                     new Claim("username", user.Username),
                     new Claim("email", user.Email),


### PR DESCRIPTION
- Add CategoryManagementDto with simplified request/response models
- Add ICategoryManagementService interface for category operations
- Add CategoryManagementService with universal CRUD logic:
  * CREATE: categoryId = 0/null
  * UPDATE: categoryId > 0, isDeleted = false
  * DELETE: categoryId > 0, isDeleted = true (soft delete)
- Add AdminCategoryController with 3 endpoints:
  * POST /api/admin/categories/manage - Universal CRUD
  * GET /api/admin/categories - Get all categories (no filtering)
  * GET /api/admin/categories/{id} - Get by ID
- Fix JWT token generation in AuthServiceSimple to use ClaimTypes.Role
- Register CategoryManagementService in Program.cs
- Remove reason field for simplicity
- Admin-only access with [Authorize(Roles = 'admin')]