### PR TITLE
Add public category APIs for users and sellers

### DIFF
--- a/PlatformFlower/Controllers/PublicCategory/GetCategoriesController.cs
+++ b/PlatformFlower/Controllers/PublicCategory/GetCategoriesController.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Mvc;
+using PlatformFlower.Models;
+using PlatformFlower.Models.DTOs;
+using PlatformFlower.Services.Common.Category;
+using PlatformFlower.Services.Common.Logging;
+using PlatformFlower.Services.Common.Response;
+
+namespace PlatformFlower.Controllers.PublicCategory
+{
+    [ApiController]
+    [Route("api/categories")]
+    public class GetCategoriesController : ControllerBase
+    {
+        private readonly ICategoryService _categoryService;
+        private readonly IResponseService _responseService;
+        private readonly IAppLogger _logger;
+
+        public GetCategoriesController(
+            ICategoryService categoryService,
+            IResponseService responseService,
+            IAppLogger logger)
+        {
+            _categoryService = categoryService;
+            _responseService = responseService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Get all active categories (Public access - for users and sellers)
+        /// Only returns categories with status = 'active'
+        /// </summary>
+        /// <returns>List of active categories</returns>
+        [HttpGet]
+        public async Task<ActionResult<ApiResponse<List<CategoryResponseDto>>>> GetActiveCategories()
+        {
+            try
+            {
+                _logger.LogInformation("Public API: Getting all active categories");
+
+                var result = await _categoryService.GetActiveCategoriesAsync();
+
+                var response = _responseService.CreateSuccessResponse(
+                    result,
+                    "Active categories retrieved successfully"
+                );
+
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting active categories: {ex.Message}", ex);
+                var response = _responseService.CreateErrorResponse<List<CategoryResponseDto>>(
+                    "An error occurred while retrieving categories"
+                );
+                return StatusCode(500, response);
+            }
+        }
+    }
+}

--- a/PlatformFlower/Controllers/PublicCategory/GetCategoryByIdController.cs
+++ b/PlatformFlower/Controllers/PublicCategory/GetCategoryByIdController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc;
+using PlatformFlower.Models;
+using PlatformFlower.Models.DTOs;
+using PlatformFlower.Services.Common.Category;
+using PlatformFlower.Services.Common.Logging;
+using PlatformFlower.Services.Common.Response;
+
+namespace PlatformFlower.Controllers.PublicCategory
+{
+    [ApiController]
+    [Route("api/categories")]
+    public class GetCategoryByIdController : ControllerBase
+    {
+        private readonly ICategoryService _categoryService;
+        private readonly IResponseService _responseService;
+        private readonly IAppLogger _logger;
+
+        public GetCategoryByIdController(
+            ICategoryService categoryService,
+            IResponseService responseService,
+            IAppLogger logger)
+        {
+            _categoryService = categoryService;
+            _responseService = responseService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Get active category by ID (Public access - for users and sellers)
+        /// Only returns category if status = 'active'
+        /// </summary>
+        /// <param name="id">Category ID</param>
+        /// <returns>Category details if active, 404 if not found or inactive</returns>
+        [HttpGet("{id}")]
+        public async Task<ActionResult<ApiResponse<CategoryResponseDto>>> GetActiveCategoryById(int id)
+        {
+            try
+            {
+                _logger.LogInformation($"Public API: Getting active category by ID: {id}");
+
+                var result = await _categoryService.GetActiveCategoryByIdAsync(id);
+
+                if (result == null)
+                {
+                    var notFoundResponse = _responseService.CreateErrorResponse<CategoryResponseDto>(
+                        $"Active category with ID {id} not found"
+                    );
+                    return NotFound(notFoundResponse);
+                }
+
+                var response = _responseService.CreateSuccessResponse(
+                    result,
+                    "Active category retrieved successfully"
+                );
+
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting active category by ID {id}: {ex.Message}", ex);
+                var response = _responseService.CreateErrorResponse<CategoryResponseDto>(
+                    "An error occurred while retrieving the category"
+                );
+                return StatusCode(500, response);
+            }
+        }
+    }
+}

--- a/PlatformFlower/Program.cs
+++ b/PlatformFlower/Program.cs
@@ -106,6 +106,9 @@ namespace PlatformFlower
             builder.Services.AddScoped<PlatformFlower.Services.Admin.UserManagement.IUserManagementService, PlatformFlower.Services.Admin.UserManagement.UserManagementService>();
             builder.Services.AddScoped<PlatformFlower.Services.Admin.CategoryManagement.ICategoryManagementService, PlatformFlower.Services.Admin.CategoryManagement.CategoryManagementService>();
 
+            // Register Common services
+            builder.Services.AddScoped<PlatformFlower.Services.Common.Category.ICategoryService, PlatformFlower.Services.Common.Category.CategoryService>();
+
             // Register Email services
             builder.Services.AddSingleton<PlatformFlower.Services.Email.IEmailConfiguration, PlatformFlower.Services.Email.EmailConfiguration>();
             builder.Services.AddScoped<PlatformFlower.Services.Email.IEmailService, PlatformFlower.Services.Email.EmailService>();

--- a/PlatformFlower/Services/Common/Category/CategoryService.cs
+++ b/PlatformFlower/Services/Common/Category/CategoryService.cs
@@ -1,0 +1,88 @@
+using Microsoft.EntityFrameworkCore;
+using PlatformFlower.Entities;
+using PlatformFlower.Models.DTOs;
+using PlatformFlower.Services.Common.Logging;
+
+namespace PlatformFlower.Services.Common.Category
+{
+    public class CategoryService : ICategoryService
+    {
+        private readonly FlowershopContext _context;
+        private readonly IAppLogger _logger;
+
+        public CategoryService(FlowershopContext context, IAppLogger logger)
+        {
+            _context = context;
+            _logger = logger;
+        }
+
+        public async Task<List<CategoryResponseDto>> GetActiveCategoriesAsync()
+        {
+            try
+            {
+                _logger.LogInformation("Getting all active categories for public access");
+
+                var categories = await _context.Categories
+                    .Where(c => c.Status == "active")
+                    .OrderBy(c => c.CategoryName)
+                    .ToListAsync();
+
+                var categoryDtos = new List<CategoryResponseDto>();
+                foreach (var category in categories)
+                {
+                    categoryDtos.Add(await MapToCategoryResponseDto(category));
+                }
+
+                _logger.LogInformation($"Retrieved {categoryDtos.Count} active categories");
+                return categoryDtos;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting active categories: {ex.Message}", ex);
+                throw;
+            }
+        }
+
+        public async Task<CategoryResponseDto?> GetActiveCategoryByIdAsync(int categoryId)
+        {
+            try
+            {
+                _logger.LogInformation($"Getting active category by ID: {categoryId}");
+
+                var category = await _context.Categories
+                    .FirstOrDefaultAsync(c => c.CategoryId == categoryId && c.Status == "active");
+
+                if (category == null)
+                {
+                    _logger.LogWarning($"Active category not found with ID: {categoryId}");
+                    return null;
+                }
+
+                var result = await MapToCategoryResponseDto(category);
+                _logger.LogInformation($"Retrieved active category: {category.CategoryName}");
+                return result;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting active category by ID {categoryId}: {ex.Message}", ex);
+                throw;
+            }
+        }
+
+        private async Task<CategoryResponseDto> MapToCategoryResponseDto(Entities.Category category)
+        {
+            var flowerCount = await _context.FlowerInfos
+                .CountAsync(f => f.CategoryId == category.CategoryId);
+
+            return new CategoryResponseDto
+            {
+                CategoryId = category.CategoryId,
+                CategoryName = category.CategoryName,
+                Status = category.Status,
+                CreatedAt = category.CreatedAt,
+                UpdatedAt = category.UpdatedAt,
+                FlowerCount = flowerCount
+            };
+        }
+    }
+}

--- a/PlatformFlower/Services/Common/Category/ICategoryService.cs
+++ b/PlatformFlower/Services/Common/Category/ICategoryService.cs
@@ -1,0 +1,20 @@
+using PlatformFlower.Models.DTOs;
+
+namespace PlatformFlower.Services.Common.Category
+{
+    public interface ICategoryService
+    {
+        /// <summary>
+        /// Get all active categories (for public access - users and sellers)
+        /// </summary>
+        /// <returns>List of active categories</returns>
+        Task<List<CategoryResponseDto>> GetActiveCategoriesAsync();
+
+        /// <summary>
+        /// Get active category by ID (for public access - users and sellers)
+        /// </summary>
+        /// <param name="categoryId">Category ID</param>
+        /// <returns>Category details if active, null if not found or inactive</returns>
+        Task<CategoryResponseDto?> GetActiveCategoryByIdAsync(int categoryId);
+    }
+}


### PR DESCRIPTION
- Created ICategoryService and CategoryService for public category access
- Added PublicCategory controllers:
  * GetCategoriesController.cs - Get all active categories (GET /api/categories)
  * GetCategoryByIdController.cs - Get category by ID if active (GET /api/categories/{id})
- Only returns categories with status = 'active', hiding inactive ones
- Public APIs don't require authentication (accessible to users and sellers)
- Admin APIs remain separate with full CRUD access to all categories
- Registered new service in Program.cs for dependency injection
- Project builds successfully with new public category endpoints