### PR TITLE
Add top popular categories API for header display

### DIFF
--- a/PlatformFlower/Controllers/PublicCategory/GetTopPopularCategoriesController.cs
+++ b/PlatformFlower/Controllers/PublicCategory/GetTopPopularCategoriesController.cs
@@ -1,0 +1,61 @@
+using Microsoft.AspNetCore.Mvc;
+using PlatformFlower.Models;
+using PlatformFlower.Models.DTOs;
+using PlatformFlower.Services.Common.Category;
+using PlatformFlower.Services.Common.Logging;
+using PlatformFlower.Services.Common.Response;
+
+namespace PlatformFlower.Controllers.PublicCategory
+{
+    [ApiController]
+    [Route("api/categories")]
+    public class GetTopPopularCategoriesController : ControllerBase
+    {
+        private readonly ICategoryService _categoryService;
+        private readonly IResponseService _responseService;
+        private readonly IAppLogger _logger;
+
+        public GetTopPopularCategoriesController(
+            ICategoryService categoryService,
+            IResponseService responseService,
+            IAppLogger logger)
+        {
+            _categoryService = categoryService;
+            _responseService = responseService;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Get top 3 most popular active categories for header display
+        /// Returns categories with most flowers, sorted by flower count (desc) then by name (asc)
+        /// Only includes categories with status = 'active'
+        /// </summary>
+        /// <returns>List of top 3 popular active categories</returns>
+        [HttpGet("top-popular")]
+        public async Task<ActionResult<ApiResponse<List<CategoryResponseDto>>>> GetTopPopularCategories()
+        {
+            try
+            {
+                _logger.LogInformation("Public API: Getting top 3 most popular active categories for header");
+
+                var result = await _categoryService.GetTopPopularCategoriesAsync();
+
+                var response = _responseService.CreateSuccessResponse(
+                    result,
+                    "Top popular categories retrieved successfully"
+                );
+
+                _logger.LogInformation($"Successfully retrieved {result.Count} top popular categories");
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting top popular categories: {ex.Message}", ex);
+                var response = _responseService.CreateErrorResponse<List<CategoryResponseDto>>(
+                    "An error occurred while retrieving top popular categories"
+                );
+                return StatusCode(500, response);
+            }
+        }
+    }
+}

--- a/PlatformFlower/Services/Common/Category/CategoryService.cs
+++ b/PlatformFlower/Services/Common/Category/CategoryService.cs
@@ -69,6 +69,50 @@ namespace PlatformFlower.Services.Common.Category
             }
         }
 
+        public async Task<List<CategoryResponseDto>> GetTopPopularCategoriesAsync()
+        {
+            try
+            {
+                _logger.LogInformation("Getting top 3 most popular active categories for header display");
+
+                // Get categories with flower count, filter active only, order by flower count desc then by name asc
+                var topCategories = await _context.Categories
+                    .Where(c => c.Status == "active")
+                    .Select(c => new
+                    {
+                        Category = c,
+                        FlowerCount = _context.FlowerInfos.Count(f => f.CategoryId == c.CategoryId)
+                    })
+                    .OrderByDescending(x => x.FlowerCount)
+                    .ThenBy(x => x.Category.CategoryName)
+                    .Take(3)
+                    .ToListAsync();
+
+                var categoryDtos = new List<CategoryResponseDto>();
+                foreach (var item in topCategories)
+                {
+                    var dto = new CategoryResponseDto
+                    {
+                        CategoryId = item.Category.CategoryId,
+                        CategoryName = item.Category.CategoryName,
+                        Status = item.Category.Status,
+                        CreatedAt = item.Category.CreatedAt,
+                        UpdatedAt = item.Category.UpdatedAt,
+                        FlowerCount = item.FlowerCount
+                    };
+                    categoryDtos.Add(dto);
+                }
+
+                _logger.LogInformation($"Retrieved {categoryDtos.Count} top popular categories");
+                return categoryDtos;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Error getting top popular categories: {ex.Message}", ex);
+                throw;
+            }
+        }
+
         private async Task<CategoryResponseDto> MapToCategoryResponseDto(Entities.Category category)
         {
             var flowerCount = await _context.FlowerInfos

--- a/PlatformFlower/Services/Common/Category/ICategoryService.cs
+++ b/PlatformFlower/Services/Common/Category/ICategoryService.cs
@@ -16,5 +16,11 @@ namespace PlatformFlower.Services.Common.Category
         /// <param name="categoryId">Category ID</param>
         /// <returns>Category details if active, null if not found or inactive</returns>
         Task<CategoryResponseDto?> GetActiveCategoryByIdAsync(int categoryId);
+
+        /// <summary>
+        /// Get top 3 most popular active categories (by flower count) for header display
+        /// </summary>
+        /// <returns>List of top 3 active categories with most flowers</returns>
+        Task<List<CategoryResponseDto>> GetTopPopularCategoriesAsync();
     }
 }


### PR DESCRIPTION
- Added GetTopPopularCategoriesAsync method to ICategoryService and CategoryService
- Created GetTopPopularCategoriesController for GET /api/categories/top-popular endpoint
- Returns top 3 active categories with most flowers for frontend header display
- Sorting logic: by flower count (desc) then by category name (asc) for ties
- Only includes categories with status = 'active', hiding inactive ones
- Public API accessible to users and sellers without authentication
- Optimized EF Core query with proper ordering and Take(3) for performance
- Follows existing project patterns with ApiResponse, logging, and error handling
- Perfect for frontend header to show most popular product categories