### PR TITLE
fix: standardize sex field validation to lowercase

### DIFF
--- a/PlatformFlower/Services/User/Profile/ProfileValidation.cs
+++ b/PlatformFlower/Services/User/Profile/ProfileValidation.cs
@@ -36,9 +36,9 @@ namespace PlatformFlower.Services.User.Profile
                 throw new ArgumentException("Birth date cannot be in the future");
             }
 
-            if (updateDto.Sex != null && !new[] { "Male", "Female", "Other" }.Contains(updateDto.Sex))
+            if (updateDto.Sex != null && !new[] { "male", "female", "other" }.Contains(updateDto.Sex))
             {
-                throw new ArgumentException("Invalid sex value. Must be Male, Female, or Other");
+                throw new ArgumentException("Invalid sex value. Must be male, female, or other");
             }
         }
 


### PR DESCRIPTION
Update ProfileValidation to use lowercase values for sex field:
- Change from 'Male', 'Female', 'Other' to 'male', 'female', 'other'
- Ensures consistency with API standards and database conventions
- Maintains validation logic while standardizing case format