### PR TITLE
feat: Implement dual-layer soft delete system for Flower_Info

### DIFF
--- a/Database.txt
+++ b/Database.txt
@@ -77,11 +77,15 @@ CREATE TABLE Flower_Info (
     price DECIMAL(10, 2) NOT NULL,
     image_url NVARCHAR(255),
     available_quantity INT NOT NULL,
+    status NVARCHAR(20) NOT NULL DEFAULT 'active',
     created_at DATETIME DEFAULT GETDATE(),
+    updated_at DATETIME DEFAULT GETDATE(),
     category_id INT,
     seller_id INT,
+    is_deleted BIT NOT NULL DEFAULT 0,
     FOREIGN KEY (category_id) REFERENCES Category(category_id),
-    FOREIGN KEY (seller_id) REFERENCES Seller(seller_id)
+    FOREIGN KEY (seller_id) REFERENCES Seller(seller_id),
+    CONSTRAINT chk_flower_status CHECK (status IN ('active', 'inactive'))
 );
 GO
 
@@ -184,4 +188,32 @@ report_id INT IDENTITY(1,1) PRIMARY KEY,
 );
 GO
 
-PRINT 'Database Flowershop created successfully with password reset functionality!';
+-- Indexes for Flower_Info status and soft delete optimization
+-- Index for public user queries (only active, non-deleted flowers)
+CREATE INDEX IX_FlowerInfo_Public_Display
+ON Flower_Info (is_deleted, status, category_id)
+INCLUDE (flower_name, price, available_quantity, image_url)
+WHERE is_deleted = 0;
+GO
+
+-- Index for seller dashboard (all flowers by seller)
+CREATE INDEX IX_FlowerInfo_Seller_Dashboard
+ON Flower_Info (seller_id, is_deleted, status)
+INCLUDE (flower_name, price, available_quantity, created_at, updated_at);
+GO
+
+-- Index for category filtering (public)
+CREATE INDEX IX_FlowerInfo_Category_Public
+ON Flower_Info (category_id, is_deleted, status)
+INCLUDE (flower_name, price, available_quantity)
+WHERE is_deleted = 0 AND status = 'active';
+GO
+
+-- Index for search and filtering
+CREATE INDEX IX_FlowerInfo_Search_Filter
+ON Flower_Info (is_deleted, status)
+INCLUDE (flower_name, flower_description, price, category_id, seller_id)
+WHERE is_deleted = 0;
+GO
+
+PRINT 'Database Flowershop created successfully with password reset functionality and soft delete support!';

--- a/PlatformFlower/Entities/FlowerInfo.cs
+++ b/PlatformFlower/Entities/FlowerInfo.cs
@@ -17,11 +17,17 @@ public partial class FlowerInfo
 
     public int AvailableQuantity { get; set; }
 
+    public string Status { get; set; } = "active";
+
     public DateTime? CreatedAt { get; set; }
+
+    public DateTime? UpdatedAt { get; set; }
 
     public int? CategoryId { get; set; }
 
     public int? SellerId { get; set; }
+
+    public bool IsDeleted { get; set; } = false;
 
     public virtual ICollection<Cart> Carts { get; set; } = new List<Cart>();
 

--- a/PlatformFlower/FlowershopContext.cs
+++ b/PlatformFlower/FlowershopContext.cs
@@ -119,6 +119,10 @@ public partial class FlowershopContext : DbContext
                 .HasDefaultValueSql("(getdate())")
                 .HasColumnType("datetime")
                 .HasColumnName("created_at");
+            entity.Property(e => e.UpdatedAt)
+                .HasDefaultValueSql("(getdate())")
+                .HasColumnType("datetime")
+                .HasColumnName("updated_at");
             entity.Property(e => e.FlowerDescription)
                 .HasMaxLength(255)
                 .HasColumnName("flower_description");
@@ -131,7 +135,14 @@ public partial class FlowershopContext : DbContext
             entity.Property(e => e.Price)
                 .HasColumnType("decimal(10, 2)")
                 .HasColumnName("price");
+            entity.Property(e => e.Status)
+                .HasMaxLength(20)
+                .HasDefaultValue("active")
+                .HasColumnName("status");
             entity.Property(e => e.SellerId).HasColumnName("seller_id");
+            entity.Property(e => e.IsDeleted)
+                .HasDefaultValue(false)
+                .HasColumnName("is_deleted");
 
             entity.HasOne(d => d.Category).WithMany(p => p.FlowerInfos)
                 .HasForeignKey(d => d.CategoryId)

--- a/PlatformFlower/Scripts/CreateFlowershopDatabase.sql
+++ b/PlatformFlower/Scripts/CreateFlowershopDatabase.sql
@@ -77,11 +77,15 @@ CREATE TABLE Flower_Info (
     price DECIMAL(10, 2) NOT NULL,
     image_url NVARCHAR(255),
     available_quantity INT NOT NULL,
+    status NVARCHAR(20) NOT NULL DEFAULT 'active',
     created_at DATETIME DEFAULT GETDATE(),
+    updated_at DATETIME DEFAULT GETDATE(),
     category_id INT,
     seller_id INT,
+    is_deleted BIT NOT NULL DEFAULT 0,
     FOREIGN KEY (category_id) REFERENCES Category(category_id),
-    FOREIGN KEY (seller_id) REFERENCES Seller(seller_id)
+    FOREIGN KEY (seller_id) REFERENCES Seller(seller_id),
+    CONSTRAINT chk_flower_status CHECK (status IN ('active', 'inactive'))
 );
 GO
 
@@ -184,4 +188,32 @@ report_id INT IDENTITY(1,1) PRIMARY KEY,
 );
 GO
 
-PRINT 'Database Flowershop created successfully with password reset functionality!';
+-- Indexes for Flower_Info status and soft delete optimization
+-- Index for public user queries (only active, non-deleted flowers)
+CREATE INDEX IX_FlowerInfo_Public_Display
+ON Flower_Info (is_deleted, status, category_id)
+INCLUDE (flower_name, price, available_quantity, image_url)
+WHERE is_deleted = 0;
+GO
+
+-- Index for seller dashboard (all flowers by seller)
+CREATE INDEX IX_FlowerInfo_Seller_Dashboard
+ON Flower_Info (seller_id, is_deleted, status)
+INCLUDE (flower_name, price, available_quantity, created_at, updated_at);
+GO
+
+-- Index for category filtering (public)
+CREATE INDEX IX_FlowerInfo_Category_Public
+ON Flower_Info (category_id, is_deleted, status)
+INCLUDE (flower_name, price, available_quantity)
+WHERE is_deleted = 0 AND status = 'active';
+GO
+
+-- Index for search and filtering
+CREATE INDEX IX_FlowerInfo_Search_Filter
+ON Flower_Info (is_deleted, status)
+INCLUDE (flower_name, flower_description, price, category_id, seller_id)
+WHERE is_deleted = 0;
+GO
+
+PRINT 'Database Flowershop created successfully with password reset functionality and soft delete support!';


### PR DESCRIPTION
- Add status field (active/inactive) for business availability state
- Add is_deleted field for soft delete functionality
- Add updated_at field for tracking all changes including deletions
- Remove unnecessary deleted_at, deleted_by, delete_reason fields for simplicity
- Update FlowerInfo entity with new properties
- Update FlowershopContext with proper column mappings
- Add database constraints and performance indexes
- Support 2-layer logic: business status + deletion state
- Clean, minimal approach following user preferences

Database changes:
- status NVARCHAR(20) DEFAULT 'active' with CHECK constraint
- updated_at DATETIME DEFAULT GETDATE()
- is_deleted BIT DEFAULT 0
- Performance indexes for public/seller queries