### PR TITLE
fix: resolve build errors and missing references

### DIFF
--- a/PlatformFlower/Controllers/AdminFlowerManagement/AdminFlowerController.cs
+++ b/PlatformFlower/Controllers/AdminFlowerManagement/AdminFlowerController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PlatformFlower.Models;
 using PlatformFlower.Models.DTOs.Flower;
 using PlatformFlower.Services.Admin.FlowerManagement;
 using PlatformFlower.Services.Common.Logging;

--- a/PlatformFlower/Controllers/AdminVoucherManagement/AdminVoucherController.cs
+++ b/PlatformFlower/Controllers/AdminVoucherManagement/AdminVoucherController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using PlatformFlower.Models;
 using PlatformFlower.Models.DTOs.Voucher;
 using PlatformFlower.Services.Admin.VoucherManagement;
 using PlatformFlower.Services.Common.Logging;

--- a/PlatformFlower/Models/DTOs/User/UserResponse.cs
+++ b/PlatformFlower/Models/DTOs/User/UserResponse.cs
@@ -21,7 +21,6 @@ namespace PlatformFlower.Models.DTOs.User
         public DateOnly? BirthDate { get; set; }
         public string? Sex { get; set; }
         public string? Avatar { get; set; }
-        public int? Points { get; set; }
         public DateTime? CreatedDate { get; set; }
         public DateTime? UpdatedDate { get; set; }
     }

--- a/PlatformFlower/Services/Admin/FlowerManagement/AdminFlowerService.cs
+++ b/PlatformFlower/Services/Admin/FlowerManagement/AdminFlowerService.cs
@@ -112,8 +112,8 @@ namespace PlatformFlower.Services.Admin.FlowerManagement
                 // Handle image upload if provided
                 if (request.ImageFile != null)
                 {
-                    var imageUrl = await _storageService.UploadFileAsync(request.ImageFile, "flowers");
-                    existingInactiveFlower.ImageUrl = imageUrl;
+                    var uploadedImageUrl = await _storageService.UploadFileAsync(request.ImageFile, "flowers");
+                    existingInactiveFlower.ImageUrl = uploadedImageUrl;
                 }
                 else if (!string.IsNullOrEmpty(request.ImageUrl))
                 {
@@ -186,8 +186,8 @@ namespace PlatformFlower.Services.Admin.FlowerManagement
             // Handle image upload if provided
             if (request.ImageFile != null)
             {
-                var imageUrl = await _storageService.UploadFileAsync(request.ImageFile, "flowers");
-                flower.ImageUrl = imageUrl;
+                var uploadedImageUrl = await _storageService.UploadFileAsync(request.ImageFile, "flowers");
+                flower.ImageUrl = uploadedImageUrl;
             }
             else if (!string.IsNullOrEmpty(request.ImageUrl))
             {

--- a/PlatformFlower/Services/User/Auth/AuthServiceSimple.cs
+++ b/PlatformFlower/Services/User/Auth/AuthServiceSimple.cs
@@ -363,7 +363,6 @@ namespace PlatformFlower.Services.User.Auth
                     BirthDate = userInfo.BirthDate,
                     Sex = userInfo.Sex,
                     Avatar = userInfo.Avatar,
-                    Points = userInfo.Points,
                     CreatedDate = userInfo.CreatedDate,
                     UpdatedDate = userInfo.UpdatedDate
                 } : null

--- a/PlatformFlower/Services/User/Profile/ProfileServiceSimple.cs
+++ b/PlatformFlower/Services/User/Profile/ProfileServiceSimple.cs
@@ -70,7 +70,6 @@ namespace PlatformFlower.Services.User.Profile
                     userInfo = new Entities.UserInfo
                     {
                         UserId = userId,
-                        Points = 100,
                         CreatedDate = DateTime.UtcNow,
                         UpdatedDate = DateTime.UtcNow
                     };
@@ -145,7 +144,6 @@ namespace PlatformFlower.Services.User.Profile
                     BirthDate = userInfo.BirthDate,
                     Sex = userInfo.Sex,
                     Avatar = userInfo.Avatar,
-                    Points = userInfo.Points,
                     CreatedDate = userInfo.CreatedDate,
                     UpdatedDate = userInfo.UpdatedDate
                 } : null


### PR DESCRIPTION
- Add missing 'using PlatformFlower.Models' to AdminFlowerController and AdminVoucherController to fix ApiResponse<> not found errors
- Remove Points property references from ProfileServiceSimple and AuthServiceSimple (Points field no longer exists in UserInfo entity)
- Remove Points property from UserResponse DTO to match entity changes
- Fix duplicate imageUrl variable declaration in AdminFlowerService by renaming to uploadedImageUrl
- Resolve all compilation errors preventing successful build
- All admin controllers now properly reference ApiResponse<> type
- User services no longer reference non-existent Points property