### PR TITLE
Implement complete voucher logic for COD and VNPay orders

### DIFF
--- a/PlatformFlower/Services/User/Order/IOrderService.cs
+++ b/PlatformFlower/Services/User/Order/IOrderService.cs
@@ -8,6 +8,7 @@ namespace PlatformFlower.Services.User.Order
         Task<OrderResponse?> GetOrderByIdAsync(int orderId, int userId);
         Task<List<OrderResponse>> GetUserOrdersAsync(int userId);
         Task<bool> UpdateOrderStatusAsync(int orderId, string status);
+        Task<bool> RestoreVoucherAsync(int orderId);
 
         // Admin methods
         Task<List<AdminOrderResponse>> GetAllOrdersAsync(AdminOrderListRequest request);


### PR DESCRIPTION
Features:
- COD orders: Deduct voucher immediately on order creation
- VNPay orders: Deduct voucher only after successful payment
- Voucher restoration: Restore voucher when orders are cancelled
- Payment method specific handling with detailed logging

Changes:
- OrderService: Separate voucher logic for COD vs VNPay
- VNPayService: Add voucher deduction on successful payment
- Add RestoreVoucherAsync method for cancelled orders
- Update IOrderService interface
- Comprehensive logging for voucher operations

Fixes:
- Voucher not being deducted for VNPay orders
- Voucher lost when VNPay payment fails
- No voucher restoration on order cancellation